### PR TITLE
Hand Displacement system introduction AND fix

### DIFF
--- a/Content.Client/DisplacementMap/DisplacementMapSystem.cs
+++ b/Content.Client/DisplacementMap/DisplacementMapSystem.cs
@@ -1,0 +1,65 @@
+﻿using Content.Shared.DisplacementMap;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Shared.Serialization.Manager;
+
+namespace Content.Client.DisplacementMap;
+
+public sealed class DisplacementMapSystem : EntitySystem
+{
+    [Dependency] private readonly ISerializationManager _serialization = default!;
+
+    public bool TryAddDisplacement(DisplacementData data, SpriteComponent sprite, int index, string key, HashSet<string> revealedLayers)
+    {
+        if (data.ShaderOverride != null)
+            sprite.LayerSetShader(index, data.ShaderOverride);
+
+        var displacementKey = $"{key}-displacement";
+        if (!revealedLayers.Add(displacementKey))
+        {
+            Log.Warning($"Duplicate key for DISPLACEMENT: {displacementKey}.");
+            return false;
+        }
+
+        //allows you not to write it every time in the YML
+        foreach (var pair in data.SizeMaps)
+        {
+            pair.Value.CopyToShaderParameters??= new()
+            {
+                LayerKey = "dummy",
+                ParameterTexture = "displacementMap",
+                ParameterUV = "displacementUV",
+            };
+        }
+
+        if (!data.SizeMaps.ContainsKey(32))
+        {
+            Log.Error($"DISPLACEMENT: {displacementKey} don't have 32x32 default displacement map");
+            return false;
+        }
+
+        // We choose a displacement map from the possible ones, matching the size with the original layer size.
+        // If there is no such a map, we use a standard 32 by 32 one
+        var displacementDataLayer = data.SizeMaps[EyeManager.PixelsPerMeter];
+        var actualRSI = sprite.LayerGetActualRSI(index);
+        if (actualRSI is not null)
+        {
+            if (actualRSI.Size.X != actualRSI.Size.Y)
+                Log.Warning($"DISPLACEMENT: {displacementKey} has a resolution that is not 1:1, things can look crooked");
+
+            var layerSize = actualRSI.Size.X;
+            if (data.SizeMaps.ContainsKey(layerSize))
+                displacementDataLayer = data.SizeMaps[layerSize];
+        }
+
+        var displacementLayer = _serialization.CreateCopy(displacementDataLayer, notNullableOverride: true);
+        displacementLayer.CopyToShaderParameters!.LayerKey = key;
+
+        sprite.AddLayer(displacementLayer, index);
+        sprite.LayerMapSet(displacementKey, index);
+
+        revealedLayers.Add(displacementKey);
+
+        return true;
+    }
+}

--- a/Content.Client/Hands/Systems/HandsSystem.cs
+++ b/Content.Client/Hands/Systems/HandsSystem.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Content.Client.DisplacementMap;
 using Content.Client.Examine;
 using Content.Client.Strip;
 using Content.Client.Verbs.UI;
@@ -30,6 +31,7 @@ namespace Content.Client.Hands.Systems
         [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
         [Dependency] private readonly StrippableSystem _stripSys = default!;
         [Dependency] private readonly ExamineSystem _examine = default!;
+        [Dependency] private readonly DisplacementMapSystem _displacement = default!;
 
         public event Action<string, HandLocation>? OnPlayerAddHand;
         public event Action<string>? OnPlayerRemoveHand;
@@ -381,6 +383,10 @@ namespace Content.Client.Hands.Systems
                 }
 
                 sprite.LayerSetData(index, layerData);
+
+                //Add displacement maps
+                if (handComp.HandDisplacement is not null)
+                    _displacement.TryAddDisplacement(handComp.HandDisplacement, sprite, index, key, revealedLayers);
             }
 
             RaiseLocalEvent(held, new HeldVisualsUpdatedEvent(uid, revealedLayers), true);

--- a/Content.Shared/DisplacementMap/DisplacementData.cs
+++ b/Content.Shared/DisplacementMap/DisplacementData.cs
@@ -1,0 +1,14 @@
+﻿namespace Content.Shared.DisplacementMap;
+
+[DataDefinition]
+public sealed partial class DisplacementData
+{
+    /// <summary>
+    /// allows you to attach different maps for layers of different sizes.
+    /// </summary>
+    [DataField(required: true)]
+    public Dictionary<int, PrototypeLayerData> SizeMaps = new();
+
+    [DataField]
+    public string? ShaderOverride = "DisplacedStencilDraw";
+}

--- a/Content.Shared/Hands/Components/HandsComponent.cs
+++ b/Content.Shared/Hands/Components/HandsComponent.cs
@@ -1,4 +1,6 @@
+using Content.Shared.DisplacementMap;
 using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Inventory;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
@@ -77,6 +79,9 @@ public sealed partial class HandsComponent : Component
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan ThrowCooldown = TimeSpan.FromSeconds(0.5f);
+
+    [DataField]
+    public DisplacementData? HandDisplacement;
 }
 
 [Serializable, NetSerializable]

--- a/Resources/Prototypes/_Floofstation/Entities/Mobs/Species/resomi.yml
+++ b/Resources/Prototypes/_Floofstation/Entities/Mobs/Species/resomi.yml
@@ -211,14 +211,18 @@
     # This doesn't work, not sure what the proper way to do this is
     - type: Hands
       handDisplacement:
-        layer:
-          sprite: "_FloofStation/Mobs/Species/Resomi/displacement.rsi"
-          state: inHand
-          copyToShaderParameters:
-#             Value required, provide a dummy. Gets overridden when applied.
-            layerKey: dummy
-            parameterTexture: displacementMap
-            parameterUV: displacementUV
+        sizeMaps:
+          32:
+            sprite: "_FloofStation/Mobs/Species/Resomi/displacement.rsi"
+            state: inHand
+#        layer:
+#          sprite: "_FloofStation/Mobs/Species/Resomi/displacement.rsi"
+#          state: inHand
+#          copyToShaderParameters:
+##             Value required, provide a dummy. Gets overridden when applied.
+#            layerKey: dummy
+#            parameterTexture: displacementMap
+#            parameterUV: displacementUV
     - type: Inventory
       speciesId: resomi
     # templateId: digitigrade


### PR DESCRIPTION
Okay so, you wouldn't believe that the entire fix was just reintroducing the HandComponent system edit from Floof. [(commit 2bb8d4a)](https://github.com/Fansana/floofstation1/commit/2bb8d4a14a2b86a7af6ab1d17f391a1ef8b9b032) 


ANYWAY

![image](https://github.com/user-attachments/assets/39c3ff33-e2cc-4fa8-8f4d-1d9872efc8ba)


This also introduces the sizemap layering and lack of shader details you see on Floof's yml, but I believe Den can have their own system later on. For now, this is what it is.

Breaking changes list:
* Possibly any other species that may benefit from displacement. However, I'm fairly certain these changes only works on the resomis in this port. We are actually doing and faring better.